### PR TITLE
Revert "Bump eslint from 3.19.0 to 6.6.0 in /plugins/cordova-plugin-file"

### DIFF
--- a/plugins/cordova-plugin-file/package.json
+++ b/plugins/cordova-plugin-file/package.json
@@ -43,7 +43,7 @@
   "deprecated": false,
   "description": "Cordova File Plugin",
   "devDependencies": {
-    "eslint": "^6.6.0",
+    "eslint": "^3.19.0",
     "eslint-config-semistandard": "^11.0.0",
     "eslint-config-standard": "^10.2.1",
     "eslint-plugin-import": "^2.3.0",


### PR DESCRIPTION
Reverts sahana/eden_mobile#3

We should not merge into plugins, this can break the build.