### PR TITLE
Revert "Bump path-parse from 1.0.6 to 1.0.7 in /plugins/cordova-sqlite-storage"

### DIFF
--- a/plugins/cordova-sqlite-storage/package-lock.json
+++ b/plugins/cordova-sqlite-storage/package-lock.json
@@ -98,9 +98,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
     "rechoir": {


### PR DESCRIPTION
Reverts sahana/eden_mobile#5

We shouldn't merge into plugins, can break the build.